### PR TITLE
Graph layout inside groups

### DIFF
--- a/src/DynamoCoreWpf/Properties/Resources.Designer.cs
+++ b/src/DynamoCoreWpf/Properties/Resources.Designer.cs
@@ -2164,6 +2164,15 @@ namespace Dynamo.Wpf.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cleanup Layout.
+        /// </summary>
+        public static string GroupContextMenuGraphLayout {
+            get {
+                return ResourceManager.GetString("GroupContextMenuGraphLayout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ungroup.
         /// </summary>
         public static string GroupContextMenuUngroup {

--- a/src/DynamoCoreWpf/Properties/Resources.en-US.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.en-US.resx
@@ -1607,6 +1607,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungroup</value>
   </data>
+  <data name="GroupContextMenuGraphLayout" xml:space="preserve">
+    <value>Cleanup Layout</value>
+  </data>
   <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
     <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again.</value>
   </data>

--- a/src/DynamoCoreWpf/Properties/Resources.resx
+++ b/src/DynamoCoreWpf/Properties/Resources.resx
@@ -1607,6 +1607,9 @@ Do you want to install the latest Dynamo update?</value>
   <data name="GroupContextMenuUngroup" xml:space="preserve">
     <value>Ungroup</value>
   </data>
+  <data name="GroupContextMenuGraphLayout" xml:space="preserve">
+    <value>Cleanup Layout</value>
+  </data>
   <data name="PackageDuplicateAssemblyWarning" xml:space="preserve">
     <value>Due to limitations in the .NET framework, it is not possible to update your package assembly while it is already loaded.  Please update the assembly while {0} is not running and try again.</value>
   </data>

--- a/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
+++ b/src/DynamoCoreWpf/ViewModels/Core/WorkspaceViewModel.cs
@@ -1054,12 +1054,31 @@ namespace Dynamo.ViewModels
         {
             if (Model.Nodes.Count() == 0)
                 return;
+            
+            var selection = DynamoSelection.Instance.Selection;
 
-            GenerateCombinedGraph();
+            bool isInternalLayout = selection.Count > 0 &&
+                selection.All(x => x is AnnotationModel ||
+                selection.Where(g => g is AnnotationModel)
+                .Any(g => (g as AnnotationModel).SelectedModels.Contains(x)));
+            
+            if (!isInternalLayout)
+            {
+                GenerateCombinedGraph();
+            }
+            else
+            {
+                GenerateCombinedGroupGraph();
+            }
+
             GenerateSeparateSubgraphs();
-            Model.LayoutSubgraphs.Skip(1).ToList().ForEach(g => RunLayoutSubgraph(g));
+            Model.LayoutSubgraphs.Skip(1).ToList().ForEach(
+                g => RunLayoutSubgraph(g, isInternalLayout));
             AvoidSubgraphOverlap();
             SaveLayoutGraph();
+
+            foreach (var model in selection)
+                model.Select();
         }
 
         private void GenerateCombinedGraph()
@@ -1119,6 +1138,61 @@ namespace Dynamo.ViewModels
                     nd.LinkedNotes.Add(note);
                 }
             }
+
+            // Support undo
+            List<ModelBase> undoItems = new List<ModelBase>();
+            undoItems.AddRange(Model.Nodes);
+            undoItems.AddRange(Model.Notes);
+            if (DynamoSelection.Instance.Selection.Count > 0)
+            {
+                undoItems = undoItems.Where(x => x.IsSelected).ToList();
+            }
+            WorkspaceModel.RecordModelsForModification(undoItems, Model.UndoRecorder);
+        }
+
+        private void GenerateCombinedGroupGraph()
+        {
+            Model.LayoutSubgraphs = new List<GraphLayout.Graph>();
+            Model.LayoutSubgraphs.Add(new GraphLayout.Graph());
+
+            GraphLayout.Graph combinedGraph = Model.LayoutSubgraphs.First();
+
+            foreach (NodeModel node in Model.Nodes)
+            {
+                combinedGraph.AddNode(node.GUID, node.Width, node.Height, node.X, node.Y,
+                    node.IsSelected || DynamoSelection.Instance.Selection.Count == 0);
+            }
+
+            foreach (ConnectorModel edge in Model.Connectors)
+            {
+                combinedGraph.AddEdge(edge.Start.Owner.GUID, edge.End.Owner.GUID,
+                    edge.Start.Center.X, edge.Start.Center.Y, edge.End.Center.X, edge.End.Center.Y);
+            }
+
+            foreach (NoteModel note in Model.Notes)
+            {
+                // Link a note to the nearest node
+                GraphLayout.Node nd = combinedGraph.Nodes.OrderBy(node =>
+                    Math.Pow(node.X + node.Width / 2 - note.X - note.Width / 2, 2) +
+                    Math.Pow(node.Y + node.Height / 2 - note.Y - note.Height / 2, 2)).FirstOrDefault();
+
+                if (nd != null)
+                {
+                    nd.LinkedNotes.Add(note);
+                }
+            }
+
+            // Support undo
+            List<ModelBase> undoItems = new List<ModelBase>();
+            foreach (var group in Model.Annotations)
+            {
+                if (group.IsSelected)
+                {
+                    group.Deselect();
+                    undoItems.AddRange(group.SelectedModels);
+                }
+            }
+            WorkspaceModel.RecordModelsForModification(undoItems, Model.UndoRecorder);
         }
 
         public void GenerateSeparateSubgraphs()
@@ -1169,13 +1243,8 @@ namespace Dynamo.ViewModels
             }
         }
 
-        private void RunLayoutSubgraph(GraphLayout.Graph graph)
+        private void RunLayoutSubgraph(GraphLayout.Graph graph, bool isInternalLayout)
         {
-            // Support undo for graph layout command
-            List<ModelBase> undoItems = new List<ModelBase>();
-            undoItems.AddRange(Model.Nodes);
-            undoItems.AddRange(Model.Notes);
-            WorkspaceModel.RecordModelsForModification(undoItems, Model.UndoRecorder);
             graph.RecordInitialPosition();
 
             // Sugiyama algorithm steps
@@ -1185,7 +1254,7 @@ namespace Dynamo.ViewModels
 
             // Node and graph positioning
             graph.DistributeNodePosition();
-            graph.SetGraphPosition();
+            graph.SetGraphPosition(isInternalLayout);
         }
 
         private void AvoidSubgraphOverlap()

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml
@@ -142,7 +142,10 @@
                            Click="OnDeleteAnnotation"/>
                 <MenuItem  Header="{x:Static p:Resources.GroupContextMenuUngroup}"
                                Name="UngroupAnnotation"
-                           Click="OnUngroupAnnotation"/>               
+                           Click="OnUngroupAnnotation"/>
+                <MenuItem Header="{x:Static p:Resources.GroupContextMenuGraphLayout}"
+                          Name="GraphLayoutAnnotation"
+                          Click="OnGraphLayoutAnnotation"/>
                 <MenuItem  Header="{x:Static p:Resources.GroupContextMenuFont}"
                                Name="ChangeSize">                   
                     <MenuItem Header ="14" Name="FontSize0" Command="{Binding ChangeFontSize}" CommandParameter="14"

--- a/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
+++ b/src/DynamoCoreWpf/Views/Core/AnnotationView.xaml.cs
@@ -227,5 +227,14 @@ namespace Dynamo.Nodes
                 ViewModel.WorkspaceViewModel.DynamoViewModel.DeleteCommand.Execute(null);
             }
         }
+
+        private void OnGraphLayoutAnnotation(object sender, RoutedEventArgs e)
+        {
+            if (ViewModel != null)
+            {
+                ViewModel.Select();
+                ViewModel.WorkspaceViewModel.DynamoViewModel.GraphAutoLayoutCommand.Execute(null);
+            }
+        }
     }
 }

--- a/src/Engine/GraphLayout/GraphLayout.cs
+++ b/src/Engine/GraphLayout/GraphLayout.cs
@@ -542,13 +542,13 @@ namespace GraphLayout
         /// <summary>
         /// To shift the whole graph back to its original position.
         /// </summary>
-        public void SetGraphPosition()
+        public void SetGraphPosition(bool isInternalLayout)
         {
             double moveX = 0;
             double moveY = 0;
 
-            // If this is a separate subgraph then retain original position
-            if (AnchorLeftEdges.Count + AnchorRightEdges.Count == 0)
+            // If this is a group or a separate subgraph then retain original position
+            if (isInternalLayout || AnchorLeftEdges.Count + AnchorRightEdges.Count == 0)
             {
                 moveX = InitialGraphCenterX - GraphCenterX;
                 moveY = InitialGraphCenterY - GraphCenterY;


### PR DESCRIPTION
### Purpose

Reference: [MAGN-8487](http://adsk-oss.myjetbrains.com/youtrack/issue/MAGN-8487)

This pull request addresses several improvements on Graph Layout algorithm to handle nodes inside groups.
- When one or more groups are selected, running the **Cleanup Node Layout** command (either from menu or keyboard shortcut) should layout the nodes inside the selected groups.
- Right click on a group and click the option **Cleanup Layout** should layout the nodes inside the selected group.
- A group should retain its initial center position after layout.

Graph layout algorithm for nodes inside a group uses the same implementation as the one for a selection of nodes ([#5376](https://github.com/DynamoDS/Dynamo/pull/5376)).

[Please refer to the chart here](https://github.com/DynamoDS/Dynamo/pull/5376#issuecomment-143971950) for my proposed behaviour of the layout command.

![image](https://cloud.githubusercontent.com/assets/6386550/10158037/c1874210-66c1-11e5-857d-878b824e3a5b.png)
### Reviewers

@aparajit-pratap
